### PR TITLE
docker-compose.ymlのマウントをpublic配下からapp配下へ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,13 @@ services:
     ports:
       - 8080:80
     volumes:
-      - ./app/public:/var/www/public
+      - ./app:/var/www
 
   php:
     build:
       context: ./phpfpm
     volumes:
-      - ./app/public:/var/www/public
+      - ./app:/var/www
 
 #  mysql:
 #    restart: always


### PR DESCRIPTION
# 概要
docker-compose.ymlのマウントを、
`./app/public:/var/www/public`
から
 `./app:/var/www`
へ変更。

# 背景
publicに起きたくないファイルもマウント可能にする
フレームワークにも対応する